### PR TITLE
Fix: Add explicit React import to Chart.tsx

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { useChartStore } from '@/store/chartStore';
 import type { DrawingObject, DrawingPoint } from '@/store/chartStore';


### PR DESCRIPTION
This change adds `import * as React from 'react';` to the beginning of `src/components/Chart.tsx`.

This is an attempt to resolve a JSX parsing error ("Unexpected token `div`. Expected jsx identifier") that may be related to the SWC compiler's handling of implicit React scope.