### PR TITLE
Fix AI error handling and accessible sidebar

### DIFF
--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -35,7 +35,13 @@ const RightSidebar = () => {
     <div className="w-80 h-full bg-sidebar border-l border-border flex flex-col"> {/* Updated border */}
       <div className="p-3 border-b border-border flex items-center"> {/* Updated border */}
         <h2 className="text-sm font-medium flex-1">AI Assistant</h2>
-        <Button variant="ghost" size="icon" className="w-6 h-6" onClick={toggleRightSidebar}> {/* Styled button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="w-6 h-6"
+          onClick={toggleRightSidebar}
+          aria-label="ChevronLeft"
+        >
           <ChevronLeft size={16} />
         </Button>
       </div>

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -82,6 +82,6 @@ export async function getAIResponse(chatMessages: ChatMessage[], chartData: Char
   } catch (error) {
     console.error('Error calling Gemini API:', error);
     console.error("Full error object from Gemini API:", JSON.stringify(error, null, 2));
-    return 'Error fetching AI response: ' + (error.message || 'Unknown error');
+    return 'Error fetching AI response.';
   }
 }


### PR DESCRIPTION
## Summary
- ensure Chevron button has an accessible label
- return generic message when AI errors occur
- add vitest run to verify

## Testing
- `npm test --run`

------
https://chatgpt.com/codex/tasks/task_e_683f3ca617b0832ab42ce47b42ce072e