### PR TITLE
Improve volume chart readability

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -14,9 +14,10 @@ import {
   XAxis, 
   YAxis, 
   CartesianGrid, 
-  Tooltip, 
+  Tooltip,
   BarChart,
-  Bar
+  Bar,
+  Cell
 } from 'recharts';
 import { ChartContainer } from '@/components/ui/chart';
 import { Button } from '@/components/ui/button';
@@ -740,10 +741,14 @@ const Chart = () => {
                 content={<CandlestickTooltip />}
                 position={{ y: 0 }}
               />
-              <Bar
-                dataKey="volume"
-                fill="rgba(33, 150, 243, 0.7)"
-              />
+              <Bar dataKey="volume">
+                {visibleData?.map((entry, i) => (
+                  <Cell
+                    key={`vol-${i}`}
+                    fill={entry.close > entry.open ? 'rgba(76,175,80,0.7)' : 'rgba(244,67,54,0.7)'}
+                  />
+                ))}
+              </Bar>
             </BarChart>
           </ChartContainer>
         </div>

--- a/src/store/chartStore.ts
+++ b/src/store/chartStore.ts
@@ -155,7 +155,7 @@ const initialMessages: ChatMessage[] = [
 export const useChartStore = create<ChartState>((set, get) => ({
   symbol: 'BTC/USD',
   setSymbol: (symbol) => set({ symbol }),
-  timeFrame: '1d',
+  timeFrame: '1m',
   setTimeFrame: (timeFrame) => set({ timeFrame }),
   chartData: generateMockChartData(),
   setChartData: (data) => {


### PR DESCRIPTION
## Summary
- color-code volume bars to match price movement
- default timeframe is now 1m for day traders and scalpers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fdd0f0048832a98a3336fd5f82a77